### PR TITLE
refactor: modify functions related to commit type [#8]

### DIFF
--- a/CommitMsgCorrector.py
+++ b/CommitMsgCorrector.py
@@ -38,11 +38,26 @@ class CommitMsgCorrector:
 def check(message):
     """ Check if a commit message is good or bad based on commit message convention
 
+        - check_type_is_specified()
+            commit message subject 에 commit type 을 포함 여부 및 이후 문장이 명령형 판단을 위해 commit type 을 제거한
+            commit message 를 리턴 받음.
+        - check_type_in_bracket()
+            commit message subject 에 bracket 안 어느 type 포함 여부 확인 ex) [DevTools], 이후 명령형 문장인 지 판단을 위해
+            bracket 부분을 제외한 commit message 를 리턴 받는다.
+
         :param message: A commit message
         :return:
     """
+
+    # Git 에서 자동 생성된 commit, 숫자만 있는 case, 빈 commit message, commit message 글자 수 1개 이하 case -> 쓰레기 data 분류
     if auto_commit_judge(message) or trash_commit_judge(message):
         return  # 이런 msg 도 분류 작업이 필요
+    # commit message subject 에 commit type 을 포함 여부 확인
+    if check_type_is_specified(message):
+        print(check_type_is_specified(message))
+    # commit message subject 에 bracket 안 어느 type 포함 여부 확인 ex) [DevTools]
+    elif check_type_in_bracket(message):
+        print(check_type_in_bracket(message))
     analyze_syntax("you " + message.lower())  # 2인칭 주어 you 로 정확도 상향 (그것도 엄청!)
 
 
@@ -66,24 +81,50 @@ def auto_commit_judge(message):
     return False
 
 
-def check_type_is_specified(commit_type):
+def check_type_is_specified(message: str):
+    """ Determine if the commit message contains the specified commit type
+
+        :param message: A commit message
+        :return: 특정 commit type 이 있다면 해당 type 이 제거된 string
+    """
+    sub_type_msg = None
+
     commit_type_list = ["feat:", "fix:", "design:", "build:", "chore:", "ci:", "docs:", "style:", "refactor:", "test:",
-                        "rename:", "remove:", "perf", "solution"]
-    if commit_type in commit_type_list:
-        return True
+                        "rename:", "remove:", "perf"]
 
-    return False
+    type_regex = r'[A-Za-z]*(\(.*\)|\s-\s.*)?:'
+    type_pattern = re.compile(type_regex)  # solution:, feat(test.py): etc 정규식
+    res = type_pattern.match(message)
+
+    if res is not None and res.start() == 0:  # commit type 정규식 표현이 존재 + 위치가 맨 앞
+        scope_regex = r'\(.*\)|\s-\s.*'  # feat(test.py): 에서 (test.py) 를 제거
+        commit_message = re.sub(scope_regex, '', res.string)
+        commit_message = commit_message.split()
+        # 특정 type 이 아닌 경우 False 를 리턴
+        # -> 처리 예정) solution: 등 회사, 자기가 구별 가능 type 을 쓸 경우도 따로 생각해두자(이 경우 권장을 해주는 방향)
+        # ex) 이런 type 은 어떤가요??
+        sub_type_msg = re.sub(type_regex, '', message).strip() if commit_message[0] in commit_type_list else None
+
+    return sub_type_msg
 
 
-def check_type_in_bracket(commit_type):
-    pattern = re.compile(r'\[[A-Za-z]*\]')
+def check_type_in_bracket(message: str):
+    """ Determine if the type enclosed in the bracket exists in front of the commit message
+        ex)
+            [DevTools] Fix regex for formateWithStyles function
+            [DevTools][Bug] Fix regex for documents
 
-    try:
-        res = pattern.match(commit_type)
-    except res is None:
-        return False
+        :param message: A commit message
+        :return sub_bracket_msg: bracket 으로 wrapped type 이 있다면 이를 제거한 commit message (string)
+    """
 
-    return True
+    bracket_regex = r'(\[[A-Za-z]*\])+'
+    pattern = re.compile(bracket_regex)
+    res = pattern.match(message)
+
+    sub_bracket_msg = re.sub(bracket_regex, '', message).strip() if res else None
+
+    return sub_bracket_msg
 
 
 def check_subject_uses_imperative(token):
@@ -130,10 +171,6 @@ def analyze_syntax(message: str):
         check_type_is_specified() 함수 인자: feat 과 : 를 합친 string 값
         ex) message: you feat: add document
     """
-    if tokens[1].text.content == '[' and check_type_in_bracket("".join(map(lambda x: x.text.content, tokens[1:4]))):
-        print(response.sentences[0].text.content)
-    if check_type_is_specified("".join(map(lambda x: x.text.content, tokens[1:3]))):
-        print(response.sentences[0].text.content)
     if check_subject_uses_imperative(tokens[1]):
         print("확인")
 


### PR DESCRIPTION
- check_type_is_specified
    - 수정 전
        language_v1 로 token 을 나눈 후 맨 앞에 있는 토큰이 올바른 commit type 을 갖는 지 확인
    - 수정 후
        language_v1 로 명령문 판단을 하기 전 commit type 부분에 대한 파싱이 먼저 필요하다고 생각해서 다음과 같이 수정
- check_type_in_bracket
    - 수정 후
        [DevTools][Bug] fix bugs 와 같이 여러 개의 bracket 이 나오는
        case 를 고려 -> 위의 함수와 같이 미리 파싱을 하도록 수정

다음 과정을 수행 후  이후 문장이 명령형인지 판단을 위해 type, bracket 을 제거한 commit message 를 리턴한다.